### PR TITLE
feat: add integration for newly introduced SDK events

### DIFF
--- a/src/features/embeddedCheckout/components/ChargeFlowEventLogger.tsx
+++ b/src/features/embeddedCheckout/components/ChargeFlowEventLogger.tsx
@@ -3,7 +3,8 @@ import { useVisualizationStore } from "../store/visualizationStore";
 import MetaViewer from "./MetaViewer";
 import { getLoggerEventStatus } from "../utils/visualizationUtils";
 
-const badgeClass = (status: string) => {
+const badgeClass = (status: string, type?: string) => {
+  if (type === "event") return "bg-blue-100 text-blue-800";
   switch (status) {
     case "running":
       return "bg-yellow-100 text-yellow-800";
@@ -62,10 +63,11 @@ const ChargeFlowEventLogger = () => {
                 <div className="flex items-center gap-3">
                   <div
                     className={`px-2 py-1 rounded text-xs font-semibold ${badgeClass(
-                      status
+                      status,
+                      e.type
                     )}`}
                   >
-                    {e.type === "callback" ? "CALLBACK" : e.type.toUpperCase()}
+                    {e.type === "callback" ? "CALLBACK" : e.type === "event" ? "EVENT" : e.type.toUpperCase()}
                   </div>
                   <div className="text-sm font-medium">
                     {e.name}

--- a/src/features/embeddedCheckout/store/checkoutStore.ts
+++ b/src/features/embeddedCheckout/store/checkoutStore.ts
@@ -17,12 +17,48 @@ import type {
   CheckoutInstanceConfig,
   ComponentListDiff,
 } from "@/features/embeddedCheckout/types/checkout";
+import { useVisualizationStore } from "./visualizationStore";
 import hashStorage from "@/utils/urlHashStorage";
 import {
   detectLocalServers,
   type ServerStatus,
 } from "@/utils/localServerDetection";
 import type { LocalModeConfig } from "@/features/embeddedCheckout/constants/checkout";
+
+const CHECKOUT_EVENTS = [
+  "destroyed",
+  "component:mounted",
+  "component:unmounted",
+  "charge:started",
+  "charge:completed",
+  "payment:success",
+  "payment:declined",
+  "payment:failed",
+  "payment:cancelled",
+  "payment:3ds:started",
+  "payment:3ds:completed",
+  "payment:3ds:failed",
+  "form:validated",
+  "form:submitted",
+  "redirect:provider",
+] as const;
+
+function attachEventListeners(checkout: CheckoutInstance): void {
+  for (const eventName of CHECKOUT_EVENTS) {
+    checkout.on(eventName, (data: unknown) => {
+      const viz = useVisualizationStore.getState();
+      if (!viz.enabled) return;
+
+      viz.addEvent({
+        type: "event",
+        name: eventName,
+        meta: data && typeof data === "object"
+          ? (data as Record<string, unknown>)
+          : { value: data },
+      });
+    });
+  }
+}
 
 interface CheckoutState {
   // Session state
@@ -201,6 +237,8 @@ export const useCheckoutStore = create<CheckoutState>()(
             localModeConfig
           );
           const version = extractSdkVersionFromMetaInfo(metaInfo);
+
+          attachEventListeners(checkoutInstance);
 
           set({
             checkout: checkoutInstance,
@@ -409,6 +447,8 @@ export const useCheckoutStore = create<CheckoutState>()(
           );
 
           // Step 6: Update store with new instance
+          attachEventListeners(newCheckoutInstance);
+
           set({
             checkout: newCheckoutInstance,
             isCheckoutInitialized: true,

--- a/src/features/embeddedCheckout/store/visualizationStore.ts
+++ b/src/features/embeddedCheckout/store/visualizationStore.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 
 export type VisualEvent = {
   id: string;
-  type: "start" | "callback" | "end";
+  type: "start" | "callback" | "end" | "event";
   name?: string;
   phase?: "start" | "end";
   timestamp: number;

--- a/src/features/embeddedCheckout/types/checkout.ts
+++ b/src/features/embeddedCheckout/types/checkout.ts
@@ -27,8 +27,12 @@ export interface CheckoutInstance {
     options?: { hidePaymentButton: boolean }
   ): DropInComponent;
   charge(): void;
-  update(config: { env?: string; longId?: string }): Promise<CheckoutInstance>; // Add update method
+  update(config: { env?: string; longId?: string }): Promise<CheckoutInstance>;
   updateLongId(longId: string): Promise<void>;
+  on(event: string, handler: (data: unknown) => void): void;
+  off(event: string, handler: (data: unknown) => void): void;
+  once(event: string, handler: (data: unknown) => void): void;
+  destroy(): void;
 }
 
 export interface CheckoutInstanceConfig {

--- a/src/features/embeddedCheckout/utils/visualizationUtils.ts
+++ b/src/features/embeddedCheckout/utils/visualizationUtils.ts
@@ -7,6 +7,7 @@ const resolveEndStatus = (result: unknown): string => {
 };
 
 export const getLoggerEventStatus = (ev: LoggerEvent) => {
+  if (ev.type === "event") return "completed";
   if (ev.type === "start") return "completed";
   if (ev.type === "end") return resolveEndStatus(ev.meta?.result);
   if (ev.type === "callback") {


### PR DESCRIPTION
This PR integrates the new Checkout Events API into the demo app so developers can see events firing in real time alongside callbacks. After initCheckout and recreateCheckout, the store subscribes to all 15 SDK events and pushes them into the visualization store as type: "event" entries. The event logger renders these with a blue EVENT badge to distinguish them from CALLBACK entries, and getLoggerEventStatus treats them as always-completed since events are instant.

One minor issue is that for successfult payments we're redirected to the success page so we can't review the success events flow (unless we add debug breakpoint somewhere in the code).

The CheckoutInstance type has been updated to include on, off, once, and destroy to reflect the new SDK surface.