### PR TITLE
PCPAY-5200 // Add support for new callbacks

### DIFF
--- a/old_docs/checkout2.js
+++ b/old_docs/checkout2.js
@@ -1,5 +1,5 @@
 const env = "checkout.integration";
-const defaultDivision = "45667";
+const defaultDivision = "58783";
 let isDifferentShippingAddress = false;
 const listRequest = {
   currency: "USD",
@@ -54,7 +54,7 @@ const listRequest = {
 function createPaymentListener(paymentComponent) {
   return function (event) {
     event.preventDefault();
-    paymentComponent.pay();
+    paymentComponent.submit();
   };
 }
 
@@ -270,7 +270,7 @@ function onComponentListChange(checkout, diff) {
    * Container of payment methods list
    */
   const paymentMethodsContainer = document.getElementById(
-    "payment-methods-container"
+    "payment-methods-container",
   );
 
   /**
@@ -295,7 +295,7 @@ function onComponentListChange(checkout, diff) {
       const parentElement = document.createElement("div");
       parentElement.classList = "payment-method-component-container";
       const componentInfo = componentsInfo.find(
-        ({ name }) => name === component
+        ({ name }) => name === component,
       );
       const template = `
                 <label
@@ -318,7 +318,7 @@ function onComponentListChange(checkout, diff) {
                         ?.map(
                           (info) =>
                             info.logoUrl &&
-                            `<img src="${info.logoUrl}" alt="${componentInfo.label}" />`
+                            `<img src="${info.logoUrl}" alt="${componentInfo.label}" />`,
                         )
                         .join("") || ""
                     }
@@ -371,7 +371,7 @@ async function initCheckout() {
     onPaymentFailure: createDummyCallHandler("onPaymentFailure", true),
     onBeforeProviderRedirect: createDummyCallHandler(
       "onBeforeProviderRedirect",
-      true
+      true,
     ),
     refetchList: createDummyCallHandler("refetchList"),
     onPaymentDeclined: createDummyCallHandler("onPaymentDeclined", true),
@@ -500,7 +500,7 @@ window.addEventListener("DOMContentLoaded", async () => {
           document.getElementById("loading-message").style = "display: none;";
           wrapper.style = "display: block;";
         }, 1000);
-      }
+      },
     );
   }
   customerDetailsForm.addEventListener("change", updateListData);
@@ -522,7 +522,7 @@ window.addEventListener("DOMContentLoaded", async () => {
       RUB: "₽", // Russian Ruble
     };
     Array.from(
-      document.getElementsByClassName("amount-with-currency-sign")
+      document.getElementsByClassName("amount-with-currency-sign"),
     ).forEach(function (el) {
       el.innerHTML = `${symbols[listRequest.currency]}${listRequest.amount}`;
     });

--- a/old_docs/index.js
+++ b/old_docs/index.js
@@ -357,7 +357,7 @@ async function initPayment() {
     function createPaymentListener(paymentComponent) {
       return function (event) {
         event.preventDefault();
-        paymentComponent.pay();
+        paymentComponent.submit();
       };
     }
 

--- a/src/features/embeddedCheckout/components/CallbackConfigRow.tsx
+++ b/src/features/embeddedCheckout/components/CallbackConfigRow.tsx
@@ -13,7 +13,7 @@ import type {
   CallbackName,
   CallbackConfig,
 } from "@/features/embeddedCheckout/types/callbacks";
-import { NOTIFICATION_CALLBACKS } from "@/features/embeddedCheckout/types/callbacks";
+import { DEPRECATED_CALLBACKS, NOTIFICATION_CALLBACKS } from "@/features/embeddedCheckout/types/callbacks";
 import ExternalLink from "@/components/ui/ExternalLink";
 
 interface CallbackConfigRowProps {
@@ -33,12 +33,21 @@ const CallbackConfigRow: React.FC<CallbackConfigRowProps> = ({
   onReset,
 }) => {
   const isNotificationOnly = NOTIFICATION_CALLBACKS.includes(callbackName);
+  const isLegacy = config.variant === "legacy";
+  const deprecatedConfigDesc = DEPRECATED_CALLBACKS[callbackName];
 
   return (
-    <div className="border rounded-lg p-3 bg-white shadow-sm">
+    <div className={
+      `border rounded-lg p-3
+      ${
+        Boolean(deprecatedConfigDesc)
+          ? 'bg-gray-50 border-gray-200 rounded-xl overflow-hidden divide-y divide-gray-100'
+          : 'bg-white shadow-sm'
+      }`}>
       {/* Header with callback name and description */}
       <div className="flex items-start gap-3 mb-3">
         <Checkbox
+          disabled={isLegacy}
           checked={config.enabled}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             onConfigChange("enabled", e.target.checked)
@@ -48,7 +57,16 @@ const CallbackConfigRow: React.FC<CallbackConfigRowProps> = ({
         />
         <div className="flex-1">
           <div className="flex items-center gap-1">
-            <h4 className="font-mono text-sm font-semibold text-gray-900">
+            <span className={
+              `shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded
+              ${
+                isLegacy
+                  ? "bg-gray-100 text-gray-400 border border-gray-200"
+                  : "bg-emerald-50 text-emerald-700"
+              }`}>
+                {isLegacy ? "legacy" : "new"}
+              </span>
+            <h4 className={`font-mono text-sm font-semibold ${isLegacy ? 'text-gray-500' : 'text-gray-900'}`}>
               {callbackName}
             </h4>
             {isNotificationOnly && (
@@ -58,22 +76,22 @@ const CallbackConfigRow: React.FC<CallbackConfigRowProps> = ({
             )}
             <InfoTooltip content={CALLBACK_DESCRIPTIONS[callbackName]} />
             <ExternalLink link={CALLBACK_DOCUMENTATION_LINKS[callbackName]} />
-            <button
+            {!isLegacy && <button
               onClick={onReset}
               className="ml-auto text-xs text-gray-500 hover:text-gray-700 underline"
               type="button"
             >
               Reset
-            </button>
+            </button>}
           </div>
           <p className="text-xs text-gray-600 mt-0.5">
-            {CALLBACK_DESCRIPTIONS[callbackName]}
+            {deprecatedConfigDesc || CALLBACK_DESCRIPTIONS[callbackName]}
           </p>
         </div>
       </div>
 
       {/* Configuration options - only visible when enabled */}
-      {config.enabled && (
+      {config.enabled && !isLegacy && (
         <div className="ml-6 space-y-3">
           {/* Flow control and log level in same row */}
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">

--- a/src/features/embeddedCheckout/components/SDKAdvancedConfiguration.tsx
+++ b/src/features/embeddedCheckout/components/SDKAdvancedConfiguration.tsx
@@ -2,9 +2,12 @@ import React, { useEffect } from "react";
 import { CALLBACK_CATEGORIES } from "@/features/embeddedCheckout/constants/callbacks";
 import { useCallbackStore } from "@/features/embeddedCheckout/store/callbackStore";
 import { useCheckoutStore } from "@/features/embeddedCheckout/store/checkoutStore";
-import type {
-  CallbackConfig,
-  CallbackName,
+import {
+  callbackPairs,
+  CallbackVariant,
+  DEPRECATED_CALLBACKS,
+  type CallbackConfig,
+  type CallbackName,
 } from "@/features/embeddedCheckout/types/callbacks";
 import Button from "@/components/ui/Button";
 import CallbackConfigRow from "./CallbackConfigRow";
@@ -15,10 +18,12 @@ const SDKAdvancedConfiguration: React.FC = () => {
   const { checkout, checkoutLoading, checkoutError } = useCheckoutStore();
   const {
     configs,
+    showDeprecated,
     hasUnsavedChanges,
     isApplying,
     error: callbackError,
     updateCallbackConfig,
+    setShowDeprecated,
     resetCallbacks,
     resetCallback,
     applyCallbacks,
@@ -92,7 +97,31 @@ const SDKAdvancedConfiguration: React.FC = () => {
           </div>
         </div>
       </div>
-
+      <div className="flex items-center justify-between mb-4">
+        <span className="text-sm font-medium text-gray-600"></span>
+        <div className="flex flex-col items-end gap-1">
+          <label className="flex items-center gap-2 cursor-pointer select-none">
+            <span className="text-sm text-gray-400">Show legacy callbacks</span>
+            <div className="relative">
+              <input
+                type="checkbox"
+                className="sr-only peer"
+                checked={showDeprecated}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setShowDeprecated(e.target.checked)
+                }
+              />
+              <div className="w-8 h-[18px] rounded-full bg-gray-200 peer-checked:bg-gray-400 transition-colors" />
+              <div className="absolute top-0.5 left-0.5 w-3.5 h-3.5 rounded-full bg-white transition-transform peer-checked:translate-x-[14px]" />
+            </div>
+          </label>
+          {showDeprecated && (
+            <span className="text-[11px] text-gray-400">
+              Read-only / New callback takes precedence
+            </span>
+          )}
+        </div>
+      </div>
       {/* Error display */}
       {(callbackError || checkoutError) && (
         <div className="bg-red-50 border border-red-200 rounded-lg p-3">
@@ -112,28 +141,40 @@ const SDKAdvancedConfiguration: React.FC = () => {
 
       {/* Scrollable callback categories */}
       <div className="flex-1 overflow-y-auto space-y-4">
-        {Object.entries(CALLBACK_CATEGORIES).map(([categoryKey, category]) => (
+        {Object.entries(CALLBACK_CATEGORIES).map(([categoryKey, category]) => {
+          const categoryCallbacks = !showDeprecated
+          ? category.callbacks.filter((clbName) => !DEPRECATED_CALLBACKS[clbName])
+          : category.callbacks;
+
+          return (
           <div key={categoryKey} className="space-y-3">
             <div>
               <h4 className="font-medium text-gray-700">{category.title}</h4>
               <p className="text-sm text-gray-600">{category.description}</p>
             </div>
-
             <div className="space-y-2">
-              {category.callbacks.map((callbackName) => (
-                <CallbackConfigRow
-                  key={callbackName}
-                  callbackName={callbackName}
-                  config={configs[callbackName]}
-                  onConfigChange={(field, value) =>
-                    handleConfigChange(callbackName, field, value)
-                  }
-                  onReset={() => handleResetCallback(callbackName)}
-                />
-              ))}
+              {categoryCallbacks.map((callbackName) => {
+                const callbackPairName = callbackPairs[callbackName];
+                const config = callbackPairName
+                ? {...configs[callbackPairName], variant: CallbackVariant.LEGACY}
+                : configs[callbackName];
+
+                return (
+                  <CallbackConfigRow
+                    key={callbackName}
+                    callbackName={callbackName}
+                    config={config}
+                    onConfigChange={(field, value) =>
+                      handleConfigChange(callbackName, field, value)
+                    }
+                    onReset={() => handleResetCallback(callbackName)}
+                  />
+                );
+              })}
             </div>
           </div>
-        ))}
+          )
+        })}
       </div>
 
       {/* Apply button - fixed at bottom */}

--- a/src/features/embeddedCheckout/constants/callbacks.ts
+++ b/src/features/embeddedCheckout/constants/callbacks.ts
@@ -26,25 +26,25 @@ export const CALLBACK_DESCRIPTIONS: Record<CallbackName, string> = {
 
 export const CALLBACK_DOCUMENTATION_LINKS: Record<CallbackName, string> = {
   onBeforeCharge:
-    "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onbeforecharge",
+    "https://checkoutdocs.payoneer.com/checkout-2/docs/callback-reference#onbeforecharge",
   onBeforeSubmit:
-    "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onbeforesubmit",
+    "https://checkoutdocs.payoneer.com/checkout-2/docs/callback-reference#onbeforesubmit",
   onBeforeError:
-    "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onbeforeerror",
+    "https://checkoutdocs.payoneer.com/checkout-2/docs/callback-reference#onbeforeerror",
   onPaymentSuccess:
-    "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onpaymentsuccess",
+    "https://checkoutdocs.payoneer.com/checkout-2/docs/callback-reference#onpaymentsuccess",
   onSubmitSuccess:
-    "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onsubmitsuccess",
+    "https://checkoutdocs.payoneer.com/checkout-2/docs/callback-reference#onsubmitsuccess",
   onPaymentFailure:
-    "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onpaymentfailure",
+    "https://checkoutdocs.payoneer.com/checkout-2/docs/callback-reference#onpaymentfailure",
   onBeforeProviderRedirect:
-    "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onbeforeproviderredirect",
+    "https://checkoutdocs.payoneer.com/checkout-2/docs/callback-reference#onbeforeproviderredirect",
   onPaymentDeclined:
-    "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onpaymentdeclined",
+    "https://checkoutdocs.payoneer.com/checkout-2/docs/callback-reference#onpaymentdeclined",
   onSubmitError:
-    "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onsubmiterror",
+    "https://checkoutdocs.payoneer.com/checkout-2/docs/callback-reference#onsubmiterror",
   onReady:
-    "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onready",
+    "https://checkoutdocs.payoneer.com/checkout-2/docs/callback-reference#onready",
 };
 
 // Log level options for UI dropdowns

--- a/src/features/embeddedCheckout/constants/callbacks.ts
+++ b/src/features/embeddedCheckout/constants/callbacks.ts
@@ -4,16 +4,22 @@ import type { CallbackName } from "@/features/embeddedCheckout/types/callbacks";
 export const CALLBACK_DESCRIPTIONS: Record<CallbackName, string> = {
   onBeforeCharge:
     "Called before a payment charge is processed. Return false to prevent the charge.",
+  onBeforeSubmit:
+    "Called before a operation is processed. Return false to prevent the operation.",
   onBeforeError:
     "Called when an error occurs. Return false to prevent default error handling.",
   onPaymentSuccess:
     "Called when a payment is successful. Return false to prevent default success handling.",
+  onSubmitSuccess:
+    "Called when a operation is successful. Return false to prevent default success handling.",
   onPaymentFailure:
     "Called when a payment fails. Return false to prevent default failure handling.",
   onBeforeProviderRedirect:
     "Called before redirecting to a payment provider. Return false to prevent redirect.",
   onPaymentDeclined:
     "Called when a payment is declined. Return false to prevent default declined handling.",
+  onSubmitError:
+    "Called when a operation is declined or failed. Return false to prevent default operation error handling.",
   onReady:
     "Called when the payment component is fully initialized and ready to accept input. Provides component name, available networks, and readiness data.",
 };
@@ -21,16 +27,22 @@ export const CALLBACK_DESCRIPTIONS: Record<CallbackName, string> = {
 export const CALLBACK_DOCUMENTATION_LINKS: Record<CallbackName, string> = {
   onBeforeCharge:
     "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onbeforecharge",
+  onBeforeSubmit:
+    "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onbeforesubmit",
   onBeforeError:
     "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onbeforeerror",
   onPaymentSuccess:
     "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onpaymentsuccess",
+  onSubmitSuccess:
+    "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onsubmitsuccess",
   onPaymentFailure:
     "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onpaymentfailure",
   onBeforeProviderRedirect:
     "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onbeforeproviderredirect",
   onPaymentDeclined:
     "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onpaymentdeclined",
+  onSubmitError:
+    "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onsubmiterror",
   onReady:
     "https://checkoutdocs.payoneer.com/checkout-2/docs/advanced-use-cases#onready",
 };
@@ -50,12 +62,15 @@ export const PROCEED_OPTIONS = [
 
 // Categories for organizing callbacks in UI
 export const CALLBACK_CATEGORIES = {
-  payment: {
-    title: "Payment Flow",
-    description: "Callbacks that control the main payment process",
+  operation: {
+    title: "Operation Flow",
+    description: "Callbacks that control the main operation process",
     callbacks: [
+      "onBeforeSubmit",
       "onBeforeCharge",
+      "onSubmitSuccess",
       "onPaymentSuccess",
+      "onSubmitError",
       "onPaymentFailure",
       "onPaymentDeclined",
     ] as CallbackName[],
@@ -81,11 +96,14 @@ export const CALLBACK_CATEGORIES = {
 // Default custom messages for each callback
 export const DEFAULT_CALLBACK_MESSAGES: Record<CallbackName, string> = {
   onBeforeCharge: "Payment charge is about to be processed",
+  onBeforeSubmit: "Operation is about to be processed",
   onBeforeError: "An error occurred during payment processing",
   onPaymentSuccess: "Payment was processed successfully",
+  onSubmitSuccess: "Operation was processed successfully",
   onPaymentFailure: "Payment processing failed",
   onBeforeProviderRedirect: "Redirecting to payment provider",
   onPaymentDeclined: "Payment was declined",
+  onSubmitError: "Operation processing failed",
   onReady: "Payment component is ready",
 };
 

--- a/src/features/embeddedCheckout/hooks/useCheckoutUI.ts
+++ b/src/features/embeddedCheckout/hooks/useCheckoutUI.ts
@@ -41,7 +41,7 @@ export const useCheckoutUI = (checkout: CheckoutInstance | null) => {
         const container = componentRefs.current[methodName];
         if (method && container) {
           const component = checkout
-            .dropIn(method.name, { hidePaymentButton: false })
+            .dropIn(method.name, { hideSubmitButton: false })
             .mount(container);
           newDropIns.push(component);
         }
@@ -62,7 +62,7 @@ export const useCheckoutUI = (checkout: CheckoutInstance | null) => {
     useCheckoutStore.setState({ isSubmitting: true });
     const activeDropIn = getActiveDropIn();
     if (activeDropIn) {
-      await activeDropIn.pay();
+      await activeDropIn.submit();
     }
     useCheckoutStore.setState({ isSubmitting: false });
   };
@@ -70,7 +70,7 @@ export const useCheckoutUI = (checkout: CheckoutInstance | null) => {
   const updatePayButton = (payButtonType: string) => {
     const isPayButtonHidden = payButtonType === "custom";
     useCheckoutStore.getState().dropIns.forEach((component) => {
-      component.element.hidePaymentButton(isPayButtonHidden);
+      component.element.hideSubmitButton(isPayButtonHidden);
     });
   };
 

--- a/src/features/embeddedCheckout/pages/SelectEnvironment.tsx
+++ b/src/features/embeddedCheckout/pages/SelectEnvironment.tsx
@@ -56,7 +56,7 @@ const SelectEnvironment = () => {
 
               <div className="bg-gray-50 p-3 rounded text-xs font-mono mb-4">
                 <div className="text-gray-500">Division</div>
-                <div className="font-semibold">45667</div>
+                <div className="font-semibold">58783</div>
               </div>
             </div>
             <Button

--- a/src/features/embeddedCheckout/store/callbackStore.ts
+++ b/src/features/embeddedCheckout/store/callbackStore.ts
@@ -17,6 +17,7 @@ export const useCallbackStore = create<CallbackStoreState>((set, get) => ({
   hasUnsavedChanges: false,
   isApplying: false,
   error: null,
+  showDeprecated: false,
 
   // Actions
   updateCallbackConfig: (
@@ -42,6 +43,13 @@ export const useCallbackStore = create<CallbackStoreState>((set, get) => ({
       hasUnsavedChanges: true,
       error: null,
     });
+  },
+
+  setShowDeprecated: (show: boolean) => {
+    set((state) => ({
+      ...state,
+      showDeprecated: show,
+    }));
   },
 
   resetCallback: (name: CallbackName) => {

--- a/src/features/embeddedCheckout/types/callbacks.ts
+++ b/src/features/embeddedCheckout/types/callbacks.ts
@@ -1,19 +1,29 @@
+export enum CallbackVariant {
+  STANDARD = "standard",
+  LEGACY = "legacy",
+  NEW = "new"
+};
+
 // Callback configuration for individual callbacks
 export interface CallbackConfig {
   enabled: boolean;
   shouldProceed: boolean;
   customMessage: string;
   logLevel: "info" | "warn" | "error";
+  variant: CallbackVariant
 }
 
 // Configuration for all supported callbacks
 export interface CallbackConfigs {
   onBeforeCharge: CallbackConfig;
+  onBeforeSubmit: CallbackConfig;
   onBeforeError: CallbackConfig;
   onPaymentSuccess: CallbackConfig;
+  onSubmitSuccess: CallbackConfig;
   onPaymentFailure: CallbackConfig;
   onBeforeProviderRedirect: CallbackConfig;
   onPaymentDeclined: CallbackConfig;
+  onSubmitError: CallbackConfig;
   onReady: CallbackConfig;
 }
 
@@ -32,6 +42,7 @@ export type CallbackHandler = (...args: any[]) => boolean | undefined;
 export interface CallbackStoreState {
   // Current callback configurations
   configs: CallbackConfigs;
+  showDeprecated: boolean;
 
   // UI state
   hasUnsavedChanges: boolean;
@@ -43,6 +54,7 @@ export interface CallbackStoreState {
     name: CallbackName,
     config: Partial<CallbackConfig>
   ) => void;
+  setShowDeprecated: (show: boolean) => void;
   resetCallbacks: () => void;
   resetCallback: (name: CallbackName) => void;
   applyCallbacks: () => Promise<void>;
@@ -56,36 +68,31 @@ export const DEFAULT_CALLBACK_CONFIG: CallbackConfig = {
   shouldProceed: false,
   customMessage: "",
   logLevel: "info",
+  variant: CallbackVariant.STANDARD
 };
 
 // Default configurations for all callbacks
 export const DEFAULT_CALLBACK_CONFIGS: CallbackConfigs = {
-  onBeforeCharge: { ...DEFAULT_CALLBACK_CONFIG },
+  onBeforeCharge: { ...DEFAULT_CALLBACK_CONFIG, variant: CallbackVariant.LEGACY },
+  onBeforeSubmit: { ...DEFAULT_CALLBACK_CONFIG, variant: CallbackVariant.NEW },
   onBeforeError: { ...DEFAULT_CALLBACK_CONFIG },
-  onPaymentSuccess: { ...DEFAULT_CALLBACK_CONFIG },
-  onPaymentFailure: { ...DEFAULT_CALLBACK_CONFIG },
+  onPaymentSuccess: { ...DEFAULT_CALLBACK_CONFIG, variant: CallbackVariant.LEGACY },
+  onSubmitSuccess: { ...DEFAULT_CALLBACK_CONFIG, variant: CallbackVariant.NEW },
+  onPaymentFailure: { ...DEFAULT_CALLBACK_CONFIG, variant: CallbackVariant.LEGACY },
   onBeforeProviderRedirect: { ...DEFAULT_CALLBACK_CONFIG },
-  onPaymentDeclined: { ...DEFAULT_CALLBACK_CONFIG },
+  onPaymentDeclined: { ...DEFAULT_CALLBACK_CONFIG, variant: CallbackVariant.LEGACY },
+  onSubmitError: { ...DEFAULT_CALLBACK_CONFIG, variant: CallbackVariant.NEW },
   onReady: { ...DEFAULT_CALLBACK_CONFIG },
 };
 
-// Callback descriptions for UI tooltips and help text
-export const CALLBACK_DESCRIPTIONS: Record<CallbackName, string> = {
-  onBeforeCharge:
-    "Called before a payment charge is processed. Return false to prevent the charge.",
-  onBeforeError:
-    "Called when an error occurs. Return false to prevent default error handling.",
-  onPaymentSuccess:
-    "Called when a payment is successful. Return false to prevent default success handling.",
-  onPaymentFailure:
-    "Called when a payment fails. Return false to prevent default failure handling.",
-  onBeforeProviderRedirect:
-    "Called before redirecting to a payment provider. Return false to prevent redirect.",
-  onPaymentDeclined:
-    "Called when a payment is declined. Return false to prevent default declined handling.",
-  onReady:
-    "Called when the payment component is fully initialized and ready to accept input. Provides component name, available networks, and readiness data.",
-};
+///Deprecated — use onSubmitError instead. onPaymentFailure will be removed in a future major version. If both are provided, onSubmitError takes precedence.
+
+export const DEPRECATED_CALLBACKS: Partial<Record<CallbackName, string>> = {
+  onBeforeCharge: "Replaced by onBeforeSubmit. onBeforeSubmit takes precedence, when both callbacks are defined.",
+  onPaymentSuccess: "Replaced by onSubmitSuccess. onSubmitSuccess takes precedence, when both callbacks are defined.",
+  onPaymentFailure: "Replaced by onSubmitError. onSubmitError takes precedence, when both callbacks are defined.",
+  onPaymentDeclined: "Replaced by onSubmitError. onSubmitError takes precedence, when both callbacks are defined."
+}
 
 // Log level options for UI
 export const LOG_LEVEL_OPTIONS = [
@@ -93,3 +100,10 @@ export const LOG_LEVEL_OPTIONS = [
   { value: "warn", label: "Warning" },
   { value: "error", label: "Error" },
 ] as const;
+
+export const callbackPairs: Partial<Record<CallbackName, CallbackName>> = {
+  onBeforeCharge: 'onBeforeSubmit',
+  onPaymentSuccess: 'onSubmitSuccess',
+  onPaymentFailure: 'onSubmitError',
+  onPaymentDeclined: 'onSubmitError',
+}

--- a/src/features/embeddedCheckout/types/checkout.ts
+++ b/src/features/embeddedCheckout/types/checkout.ts
@@ -12,10 +12,10 @@ export interface PaymentMethod {
 export interface DropInComponent {
   mount(element: HTMLElement | null): DropInComponent;
   unmount(): void;
-  pay(): Promise<void>;
-  updateNode(options: { hidePaymentButton: boolean }): void;
+  submit(): Promise<void>;
+  updateNode(options: { hideSubmitButton: boolean }): void;
   element: {
-    hidePaymentButton: (hide: boolean) => void;
+    hideSubmitButton: (hide: boolean) => void;
   };
 }
 
@@ -24,7 +24,7 @@ export interface CheckoutInstance {
   dropInComponents: Record<string, DropInComponent>;
   dropIn(
     methodName: string,
-    options?: { hidePaymentButton: boolean }
+    options?: { hideSubmitButton: boolean }
   ): DropInComponent;
   charge(): void;
   update(config: { env?: string; longId?: string }): Promise<CheckoutInstance>; // Add update method
@@ -37,11 +37,14 @@ export interface CheckoutInstanceConfig {
   refetchListBeforeCharge?: boolean;
   preload: string[];
   onBeforeCharge: unknown;
+  onBeforeSubmit: unknown;
   onBeforeError: unknown;
   onPaymentSuccess: unknown;
+  onSubmitSuccess: unknown;
   onPaymentFailure: unknown;
   onBeforeProviderRedirect: unknown;
   onPaymentDeclined: unknown;
+  onSubmitError: unknown;
 }
 
 export interface ListSessionRequest {


### PR DESCRIPTION

https://github.com/user-attachments/assets/890f33fc-667a-4df4-8e14-7c4731ee3a8e

Implement new callbacks view presented with old ones.
`pay` method is replaced with `submit`.
`hidePaymentButton` config is replaced with `hideSubmitButton`.
`onBeforeCharge` callback is replaced with `onBeforeSubmit`.
`onPaymentSuccess` callback is replaced with `onSubmitSuccess`.
`onPaymentFailure` & `onPaymentDeclined` callbacks are replaced with `onSubmitError`.
